### PR TITLE
fix(service)crush fixing for api22,28,29

### DIFF
--- a/app/src/main/java/me/weishu/leoric/demo/Service1.java
+++ b/app/src/main/java/me/weishu/leoric/demo/Service1.java
@@ -17,12 +17,21 @@
 
 package me.weishu.leoric.demo;
 
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
+import android.os.Build;
 import android.os.IBinder;
 
-public class Service1 extends Service{
+import androidx.core.app.NotificationCompat;
 
+public class Service1 extends Service{
+    private final static int NOTIFY_ID = 101;
+    Notification notification;
+    NotificationManager manager;
     @Override
     public void onCreate() {
         super.onCreate();
@@ -31,5 +40,38 @@ public class Service1 extends Service{
     @Override
     public IBinder onBind(Intent intent) {
         return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        showNotification();
+        startForeground(NOTIFY_ID,notification);
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+    private void showNotification() {
+        manager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        Intent hangIntent = new Intent(this, MainActivity.class);
+
+        PendingIntent hangPendingIntent = PendingIntent.getActivity(this, 1002, hangIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+        String CHANNEL_ID = "your_custom_id";//应用频道Id唯一值， 长度若太长可能会被截断，
+        String CHANNEL_NAME = "your_custom_name";//最长40个字符，太长会被截断
+        notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle("通知Title")
+                .setContentText("通知Content")
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentIntent(hangPendingIntent)
+                .setAutoCancel(true)
+                .build();
+
+        //Android 8.0 以上需包添加渠道
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID,
+                    CHANNEL_NAME, NotificationManager.IMPORTANCE_LOW);
+            manager.createNotificationChannel(notificationChannel);
+        }
+
+        manager.notify(NOTIFY_ID, notification);
     }
 }

--- a/app/src/main/java/me/weishu/leoric/demo/Service2.java
+++ b/app/src/main/java/me/weishu/leoric/demo/Service2.java
@@ -17,11 +17,22 @@
 
 package me.weishu.leoric.demo;
 
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
+import android.os.Build;
 import android.os.IBinder;
 
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
 public class Service2 extends Service{
+    private final static int NOTIFY_ID = 100;
+    Notification notification;
+    NotificationManager manager;
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -30,6 +41,33 @@ public class Service2 extends Service{
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        showNotification();
+        startForeground(NOTIFY_ID,notification);
         return Service.START_NOT_STICKY;
+    }
+    private void showNotification() {
+        manager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        Intent hangIntent = new Intent(this, MainActivity.class);
+
+        PendingIntent hangPendingIntent = PendingIntent.getActivity(this, 1001, hangIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+        String CHANNEL_ID = "your_custom_id";//应用频道Id唯一值， 长度若太长可能会被截断，
+        String CHANNEL_NAME = "your_custom_name";//最长40个字符，太长会被截断
+        notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle("通知Title")
+                .setContentText("通知Content")
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentIntent(hangPendingIntent)
+                .setAutoCancel(true)
+                .build();
+
+        //Android 8.0 以上需包添加渠道
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID,
+                    CHANNEL_NAME, NotificationManager.IMPORTANCE_LOW);
+            manager.createNotificationChannel(notificationChannel);
+        }
+
+        manager.notify(NOTIFY_ID, notification);
     }
 }

--- a/library/src/main/java/me/weishu/leoric/LeoricProcessImpl.java
+++ b/library/src/main/java/me/weishu/leoric/LeoricProcessImpl.java
@@ -151,7 +151,9 @@ public class LeoricProcessImpl implements ILeoricProcess {
             mServiceData.writeStrongBinder(null);
             intent.writeToParcel(mServiceData, 0);
             mServiceData.writeString(null);
-            mServiceData.writeString(context.getPackageName());
+            if (Build.VERSION.SDK_INT > 22) {//适配5.1(22)
+                mServiceData.writeString(context.getPackageName());
+            }
             mServiceData.writeInt(0);
         }
 


### PR DESCRIPTION
MSG:1)remove packagename of parcel for api22.
2)invoke startForeground in service to prevent crush in api 28,29.

Signed-off-by: fujingdong <fujingdong@xiaomi.com>